### PR TITLE
Déplacement des comparaisons de règles vers le menu principal

### DIFF
--- a/index.html
+++ b/index.html
@@ -494,7 +494,6 @@
 
             <div class="map-modal-tabs">
                 <button class="tab-link active" data-tab="map-content-panel">Carte</button>
-                <button class="tab-link" data-tab="info-content-panel">Regles Adapter pour la campagne</button>
             </div>
 
             <div id="map-content-panel" class="map-modal-content-panel active">
@@ -515,9 +514,6 @@
                 <div id="galactic-map-container">
                 </div>
             </div>
-
-            <div id="info-content-panel" class="map-modal-content-panel hidden">
-                </div>
         </div>
     </div>
 
@@ -686,6 +682,14 @@
             </div>
             <div id="full-history-entries" style="overflow-y: auto; height: 60vh; background-color: #1e1e1e; padding: 10px; border: 1px solid var(--border-color);">
             </div>
+        </div>
+    </div>
+
+    <div id="rules-modal" class="modal hidden">
+        <div class="modal-content large">
+            <span class="close-btn">&times;</span>
+            <h3 id="rules-modal-title">Comparaison des Règles</h3>
+            <div id="rules-content-panel"></div>
         </div>
     </div>
 

--- a/main.js
+++ b/main.js
@@ -30,6 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const mapContainer = document.getElementById('galactic-map-container');
     const npcCombatModal = document.getElementById('npc-combat-modal');
     const pvpCombatModal = document.getElementById('pvp-combat-modal');
+    const rulesModal = document.getElementById('rules-modal');
     
     const actionLogContainer = document.getElementById('action-log-container');
     const actionLogHeader = document.getElementById('action-log-header');
@@ -127,6 +128,11 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 showNotification("Erreur : ce joueur n'a pas de système assigné.", 'error');
             }
+        } else if (target.matches('.rules-btn')) {
+            const playerIndex = parseInt(target.dataset.index);
+            const player = campaignData.players[playerIndex];
+            renderCampaignRulesTab(player, 'rules-content-panel');
+            openModal(rulesModal);
         } else if (target.matches('.delete-player-btn')) {
             const index = parseInt(target.dataset.index);
             const playerToDelete = campaignData.players[index];
@@ -685,7 +691,6 @@ document.addEventListener('DOMContentLoaded', () => {
         if (e.target.id === 'show-map-btn') {
             openModal(mapModal);
             currentMapScale = 1;
-        renderCampaignRulesTab(); 
             setTimeout(renderGalacticMap, 50);
         } else if (e.target.id === 'show-history-btn') {
             openFullHistoryModal();

--- a/render.js
+++ b/render.js
@@ -60,6 +60,7 @@ const renderPlayerList = () => {
                 <button class="btn-secondary edit-player-btn" data-index="${index}">Modifier</button>
                 <button class="btn-danger delete-player-btn" data-index="${index}">Supprimer</button>
                 <button class="btn-secondary world-btn" data-index="${index}">JOUER</button>
+                <button class="btn-secondary rules-btn" data-index="${index}">Règle</button>
             </div>
         `;
         playerListDiv.appendChild(card);
@@ -845,10 +846,13 @@ const renderActionLog = () => {
 /**
  * Remplit l'onglet des règles de campagne adaptées dans la modale de la carte.
  */
-function renderCampaignRulesTab() {
-    const infoPanel = document.getElementById('info-content-panel');
+function renderCampaignRulesTab(player = null, containerId = 'rules-content-panel') {
+    const infoPanel = document.getElementById(containerId);
+    if (!infoPanel) return;
     infoPanel.innerHTML = ''; // Vider le contenu précédent
-    const player = campaignData.players.find(p => p.id === mapViewingPlayerId);
+    if (!player) {
+        player = campaignData.players.find(p => p.id === mapViewingPlayerId);
+    }
 
     if (!player || !campaignRuleDifferences) {
         infoPanel.innerHTML = `<p>Aucune donnée de règle de campagne à afficher.</p>`;
@@ -912,6 +916,6 @@ function renderCampaignRulesTab() {
             </div>
         </div>
     `;
-    
+
     infoPanel.innerHTML = tableHTML;
 }

--- a/style.css
+++ b/style.css
@@ -195,6 +195,10 @@ label {
     padding: 8px 5px;
 }
 
+.player-card-actions .rules-btn {
+    flex-basis: 100%;
+}
+
 
 /* --- Vue Fiche de Progression (Roster View) --- */
 .roster-header {


### PR DESCRIPTION
## Résumé
- Ajoute un bouton **Règle** pour chaque joueur affichant les comparaisons des règles officielles
- Retire l'onglet de comparaison des règles de la carte galactique
- Assure un affichage dédié via une nouvelle fenêtre modale

## Test
- `npm test` (échoue : package.json manquant)
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68972738e6e08332959e97a9bc6aa234