### PR TITLE
feat: add fullscreen mode for tablets

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
                 <button id="export-btn">Exporter la Campagne (JSON)</button>
                 <button id="import-btn">Importer la Campagne (JSON)</button>
                 <input type="file" id="import-file" accept=".json" style="display: none;">
+                <button id="fullscreen-btn">Plein écran</button>
             </div>
             <p class="storage-warning">
               ⚠️ **Attention :** Toutes les données sont sauvegardées localement dans votre navigateur.

--- a/main.js
+++ b/main.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const exportBtn = document.getElementById('export-btn');
     const importBtn = document.getElementById('import-btn');
     const importFile = document.getElementById('import-file');
+    const fullscreenBtn = document.getElementById('fullscreen-btn');
     const resetCampaignBtn = document.getElementById('reset-campaign-btn');
     mapModal = document.getElementById('map-modal');
     const mapContainer = document.getElementById('galactic-map-container');
@@ -54,6 +55,19 @@ document.addEventListener('DOMContentLoaded', () => {
     exportBtn.addEventListener('click', handleExport);
     importBtn.addEventListener('click', () => importFile.click());
     importFile.addEventListener('change', handleImport);
+    if (fullscreenBtn) {
+        fullscreenBtn.addEventListener('click', () => {
+            if (!document.fullscreenElement) {
+                document.documentElement.requestFullscreen();
+            } else {
+                document.exitFullscreen();
+            }
+        });
+
+        document.addEventListener('fullscreenchange', () => {
+            fullscreenBtn.textContent = document.fullscreenElement ? 'Quitter le plein écran' : 'Plein écran';
+        });
+    }
     backToListBtn.addEventListener('click', () => switchView('list'));
 
     backToSystemBtn.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -1093,6 +1093,15 @@ label {
 }
 
 /* --- Responsivité --- */
+#fullscreen-btn {
+    display: none;
+}
+
+@media (hover: none) and (pointer: coarse) {
+    #fullscreen-btn {
+        display: inline-block;
+    }
+}
 @media (max-width: 900px) {
     .unit-card-body { grid-template-columns: 1fr; }
     .upgrades-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- add a `Plein écran` control in the campaign header
- show the fullscreen button only on touch devices via CSS
- toggle fullscreen mode and button label through JavaScript

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689742c295f883328f72ba819bb94cd9