### PR TITLE
Add Netlify online save and load

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# CHATGPT5-Croisade
+# Nexus Crusade Tracker
+
+Cette application permet de gérer une campagne de croisade Warhammer 40k.
+
+## Sauvegarde en ligne
+
+Les boutons **Sauvegarder en ligne** et **Charger en ligne** utilisent des fonctions Netlify pour stocker ou récupérer la campagne.

--- a/engine.js
+++ b/engine.js
@@ -803,3 +803,39 @@ const handleImport = (event) => {
     reader.readAsText(file);
     event.target.value = null; // Permet de ré-importer le même fichier
 };
+
+const saveDataOnline = async () => {
+    const key = prompt("Identifiant de sauvegarde en ligne :");
+    if (!key) return;
+    try {
+        const response = await fetch(`/.netlify/functions/saveCampaign?key=${encodeURIComponent(key)}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(campaignData)
+        });
+        if (!response.ok) throw new Error('Network error');
+        showNotification("Sauvegarde en ligne réussie !", 'success');
+    } catch (err) {
+        console.error('Erreur sauvegarde en ligne :', err);
+        showNotification("Échec de la sauvegarde en ligne.", 'error');
+    }
+};
+
+const loadDataOnline = async () => {
+    const key = prompt("Identifiant de la sauvegarde à charger :");
+    if (!key) return;
+    try {
+        const response = await fetch(`/.netlify/functions/loadCampaign?key=${encodeURIComponent(key)}`);
+        if (!response.ok) throw new Error('Save not found');
+        const data = await response.json();
+        campaignData = data;
+        migrateData();
+        saveData();
+        renderPlayerList();
+        switchView('list');
+        showNotification("Chargement en ligne réussi !", 'success');
+    } catch (err) {
+        console.error('Erreur chargement en ligne :', err);
+        showNotification("Échec du chargement en ligne.", 'error');
+    }
+};

--- a/index.html
+++ b/index.html
@@ -18,11 +18,13 @@
                 <button id="export-btn">Exporter la Campagne (JSON)</button>
                 <button id="import-btn">Importer la Campagne (JSON)</button>
                 <input type="file" id="import-file" accept=".json" style="display: none;">
+                <button id="save-online-btn">Sauvegarder en ligne</button>
+                <button id="load-online-btn">Charger en ligne</button>
                 <button id="fullscreen-btn">Plein écran</button>
             </div>
             <p class="storage-warning">
-              ⚠️ **Attention :** Toutes les données sont sauvegardées localement dans votre navigateur.
-                Utilisez l'export pour créer des sauvegardes !
+              ⚠️ <strong>Attention :</strong> Toutes les données sont sauvegardées localement dans votre navigateur.
+                Utilisez l'export ou la sauvegarde en ligne pour créer des sauvegardes !
             </p>
             <div class="management-controls">
                 <button id="reset-campaign-btn" class="btn-danger">Explosion du Warp (Réinitialiser)</button>

--- a/main.js
+++ b/main.js
@@ -25,6 +25,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const exportBtn = document.getElementById('export-btn');
     const importBtn = document.getElementById('import-btn');
     const importFile = document.getElementById('import-file');
+    const saveOnlineBtn = document.getElementById('save-online-btn');
+    const loadOnlineBtn = document.getElementById('load-online-btn');
     const fullscreenBtn = document.getElementById('fullscreen-btn');
     const resetCampaignBtn = document.getElementById('reset-campaign-btn');
     mapModal = document.getElementById('map-modal');
@@ -55,6 +57,8 @@ document.addEventListener('DOMContentLoaded', () => {
     exportBtn.addEventListener('click', handleExport);
     importBtn.addEventListener('click', () => importFile.click());
     importFile.addEventListener('change', handleImport);
+    if (saveOnlineBtn) saveOnlineBtn.addEventListener('click', saveDataOnline);
+    if (loadOnlineBtn) loadOnlineBtn.addEventListener('click', loadDataOnline);
     if (fullscreenBtn) {
         fullscreenBtn.addEventListener('click', () => {
             if (!document.fullscreenElement) {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  publish = "."
+  functions = "netlify/functions"

--- a/netlify/functions/loadCampaign.js
+++ b/netlify/functions/loadCampaign.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'GET') {
+    return {
+      statusCode: 405,
+      body: JSON.stringify({ error: 'Method Not Allowed' })
+    };
+  }
+
+  const key = event.queryStringParameters && event.queryStringParameters.key ? event.queryStringParameters.key : 'default';
+  const filePath = path.resolve(__dirname, '../data', `${key}.json`);
+
+  try {
+    if (!fs.existsSync(filePath)) {
+      return { statusCode: 404, body: JSON.stringify({ error: 'Save not found' }) };
+    }
+    const data = fs.readFileSync(filePath, 'utf8');
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': 'application/json' },
+      body: data
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Failed to load data', details: err.message })
+    };
+  }
+};

--- a/netlify/functions/saveCampaign.js
+++ b/netlify/functions/saveCampaign.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+exports.handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      body: JSON.stringify({ error: 'Method Not Allowed' })
+    };
+  }
+
+  const key = event.queryStringParameters && event.queryStringParameters.key ? event.queryStringParameters.key : 'default';
+  const dataDir = path.resolve(__dirname, '../data');
+  const filePath = path.join(dataDir, `${key}.json`);
+
+  try {
+    if (!fs.existsSync(dataDir)) {
+      fs.mkdirSync(dataDir, { recursive: true });
+    }
+    fs.writeFileSync(filePath, event.body || '{}', 'utf8');
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ success: true })
+    };
+  } catch (err) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Failed to save data', details: err.message })
+    };
+  }
+};


### PR DESCRIPTION
## Summary
- allow campaigns to be saved/loaded online via Netlify functions
- add Netlify function handlers and configuration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974b9e0f6883329f8b3adcedf66be9