### PR TITLE
docs: add Netlify usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,38 @@
 
 Cette application permet de gérer une campagne de croisade Warhammer 40k.
 
-## Sauvegarde en ligne
+## Lancer le projet
 
-Les boutons **Sauvegarder en ligne** et **Charger en ligne** utilisent des fonctions Netlify pour stocker ou récupérer la campagne.
+L'application repose sur des fonctions serverless hébergées par Netlify. Pour les utiliser en local :
+
+1. Installez l'outil Netlify CLI si nécessaire :
+   ```bash
+   npm install -g netlify-cli
+   ```
+2. Depuis la racine du projet, lancez le serveur de développement :
+   ```bash
+   netlify dev
+   ```
+
+Ce serveur expose à la fois le site statique et les fonctions. Les boutons **Sauvegarder en ligne** et **Charger en ligne** n'effectuent leurs opérations qu'au sein de cet environnement Netlify.
+
+## Déploiement
+
+Pour publier le site et ses fonctions sur Netlify :
+
+1. Déploiement de prévisualisation :
+   ```bash
+   netlify deploy
+   ```
+2. Déploiement en production :
+   ```bash
+   netlify deploy --prod
+   ```
+
+Une fois déployées, les fonctions sont accessibles via des URLs de la forme :
+
+```
+https://<nom-du-site>.netlify.app/.netlify/functions/<nom-de-la-fonction>
+```
+
+Vous pouvez utiliser cette structure (`/.netlify/functions/...`) pour tester chaque fonction directement.


### PR DESCRIPTION
## Summary
- explain how to launch the project locally with `netlify dev`
- note that online save/load buttons require a Netlify environment
- document Netlify deployment commands and serverless function URLs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974fc2ad4483329ae1b1d415d91271