### PR TITLE
Use Netlify Blobs for campaign persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -5,3 +5,14 @@ Cette application permet de gérer une campagne de croisade Warhammer 40k.
 ## Sauvegarde en ligne
 
 Les boutons **Sauvegarder en ligne** et **Charger en ligne** utilisent des fonctions Netlify pour stocker ou récupérer la campagne.
+
+## Configuration des sauvegardes
+
+Les fonctions Netlify utilisent le service **Netlify Blobs** pour un stockage persistant des campagnes. Pour les utiliser hors de la plateforme Netlify, définissez les variables d'environnement suivantes :
+
+- `NETLIFY_BLOBS_URL`
+- `NETLIFY_BLOBS_TOKEN`
+
+Ces variables doivent avoir des droits de lecture et d'écriture sur le store utilisé (`campaigns`). Sur Netlify, elles sont fournies automatiquement.
+
+Après récupération du projet, installez les dépendances avec `npm install` afin d'obtenir notamment `@netlify/blobs`.

--- a/netlify/functions/loadCampaign.js
+++ b/netlify/functions/loadCampaign.js
@@ -1,5 +1,4 @@
-const fs = require('fs');
-const path = require('path');
+const { getStore } = require('@netlify/blobs');
 
 exports.handler = async (event) => {
   if (event.httpMethod !== 'GET') {
@@ -10,13 +9,13 @@ exports.handler = async (event) => {
   }
 
   const key = event.queryStringParameters && event.queryStringParameters.key ? event.queryStringParameters.key : 'default';
-  const filePath = path.resolve(__dirname, '../data', `${key}.json`);
 
   try {
-    if (!fs.existsSync(filePath)) {
+    const store = getStore('campaigns');
+    const data = await store.get(key);
+    if (!data) {
       return { statusCode: 404, body: JSON.stringify({ error: 'Save not found' }) };
     }
-    const data = fs.readFileSync(filePath, 'utf8');
     return {
       statusCode: 200,
       headers: { 'Content-Type': 'application/json' },
@@ -25,7 +24,7 @@ exports.handler = async (event) => {
   } catch (err) {
     return {
       statusCode: 500,
-      body: JSON.stringify({ error: 'Failed to load data', details: err.message })
+      body: JSON.stringify({ error: 'Failed to load data from persistent store', details: err.message })
     };
   }
 };

--- a/netlify/functions/saveCampaign.js
+++ b/netlify/functions/saveCampaign.js
@@ -1,5 +1,4 @@
-const fs = require('fs');
-const path = require('path');
+const { getStore } = require('@netlify/blobs');
 
 exports.handler = async (event) => {
   if (event.httpMethod !== 'POST') {
@@ -10,22 +9,18 @@ exports.handler = async (event) => {
   }
 
   const key = event.queryStringParameters && event.queryStringParameters.key ? event.queryStringParameters.key : 'default';
-  const dataDir = path.resolve(__dirname, '../data');
-  const filePath = path.join(dataDir, `${key}.json`);
 
   try {
-    if (!fs.existsSync(dataDir)) {
-      fs.mkdirSync(dataDir, { recursive: true });
-    }
-    fs.writeFileSync(filePath, event.body || '{}', 'utf8');
+    const store = getStore('campaigns');
+    await store.set(key, event.body || '{}');
     return {
       statusCode: 200,
-      body: JSON.stringify({ success: true })
+      body: JSON.stringify({ success: true, message: 'Campaign saved to persistent store' })
     };
   } catch (err) {
     return {
       statusCode: 500,
-      body: JSON.stringify({ error: 'Failed to save data', details: err.message })
+      body: JSON.stringify({ error: 'Failed to save data to persistent store', details: err.message })
     };
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "chatgpt5-croisade",
+  "version": "1.0.0",
+  "description": "Cette application permet de gérer une campagne de croisade Warhammer 40k.",
+  "main": "main.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@netlify/blobs": "^1.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- replace file-based storage with Netlify Blobs in save/load functions
- document required Netlify Blobs configuration and dependency
- add package manifest and node_modules ignore

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68974fe951048332981432fce8e5a497