### PR TITLE
Use JSON storage for campaigns

### DIFF
--- a/netlify/functions/loadCampaign.js
+++ b/netlify/functions/loadCampaign.js
@@ -30,10 +30,14 @@ exports.handler = async (event) => {
     if (!siteID || !token) throw new Error("BLOBS_SITE_ID ou BLOBS_TOKEN manquant(s).");
 
     const store = getStore("campaigns", { siteID, token });
-    const data = await store.get(key); // string JSON
+    const data = await store.getJSON(key);
 
     if (!data) return respond(404, { error: "not found" });
-    return { statusCode: 200, headers: { ...corsHeaders(), "Content-Type": "application/json" }, body: data };
+    return {
+      statusCode: 200,
+      headers: { ...corsHeaders(), "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    };
   } catch (err) {
     console.error("loadCampaign error:", err);
     return respond(500, { error: "load failed", details: String(err?.message || err) });

--- a/netlify/functions/saveCampaign.js
+++ b/netlify/functions/saveCampaign.js
@@ -37,8 +37,7 @@ exports.handler = async (event) => {
       event.headers["content-type"]?.includes("application/json")
         ? (event.body || "{}")
         : "{}";
-
-    await store.set(key, body); // ou store.setJSON(key, JSON.parse(body))
+    await store.setJSON(key, JSON.parse(body));
     return respond(200, { success: true, message: "saved" });
   } catch (err) {
     console.error("saveCampaign error:", err);


### PR DESCRIPTION
## Summary
- Use `store.setJSON` with parsed request body to persist campaign data as JSON
- Retrieve campaigns with `getJSON` and respond with a JSON string

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689763f81d248332a6a45436a0f37324