### PR TITLE
Use absolute base URL for campaign save function

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -809,7 +809,8 @@ const saveDataOnline = async () => {
     const key = prompt("Identifiant de sauvegarde en ligne :");
     if (!key) return;
     try {
-        const response = await fetch(`/.netlify/functions/saveCampaign?key=${encodeURIComponent(key)}`, {
+        const base = window.location.origin;
+        const response = await fetch(`${base}/.netlify/functions/saveCampaign?key=${encodeURIComponent(key)}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(campaignData)


### PR DESCRIPTION
## Summary
- Ensure online campaign saving uses absolute Netlify function URL based on `window.location.origin`.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6897640c66cc8332b399dc5482f2d01f