### PR TITLE
fix: enable blob storage external module

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,6 @@
   functions = "netlify/functions"
 [functions]
   node_bundler = "esbuild"
-  external_node_modules = []
+  # Ensure ESM-only packages like @netlify/blobs aren't bundled so they can
+  # be loaded via dynamic import at runtime
+  external_node_modules = ["@netlify/blobs"]


### PR DESCRIPTION
## Summary
- ensure `@netlify/blobs` is excluded from bundling so Netlify functions can import it at runtime

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689766bc16d083329dfee1b7c4b910b8