### PR TITLE
fix: configure Netlify Blobs store

### DIFF
--- a/netlify/functions/loadCampaign.js
+++ b/netlify/functions/loadCampaign.js
@@ -29,10 +29,10 @@ exports.handler = async (event) => {
     console.log("loadCampaign env:", !!siteID, !!token); // true true attendu
     if (!siteID || !token) throw new Error("BLOBS_SITE_ID ou BLOBS_TOKEN manquant(s).");
 
-    const store = getStore("campaigns", { siteID, token });
-    const data = await store.getJSON(key);
+    const store = getStore({ name: "campaigns", siteID, token });
+    const data = await store.get(key, { type: "json" });
 
-    if (!data) return respond(404, { error: "not found" });
+    if (data === null) return respond(404, { error: "not found" });
     return {
       statusCode: 200,
       headers: { ...corsHeaders(), "Content-Type": "application/json" },

--- a/netlify/functions/saveCampaign.js
+++ b/netlify/functions/saveCampaign.js
@@ -31,7 +31,7 @@ exports.handler = async (event) => {
     console.log("saveCampaign env:", !!siteID, !!token); // doit afficher true true
     if (!siteID || !token) throw new Error("BLOBS_SITE_ID ou BLOBS_TOKEN manquant(s).");
 
-    const store = getStore("campaigns", { siteID, token });
+    const store = getStore({ name: "campaigns", siteID, token });
 
     const body =
       event.headers["content-type"]?.includes("application/json")


### PR DESCRIPTION
## Summary
- use new `getStore` signature with explicit site and token
- load campaign JSON via `get` and handle missing data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689768138d7c8332ad88b4fab3f31dd3