### PR TITLE
Protect roster adjustments with admin mode

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -31,6 +31,8 @@ let mapViewingPlayerId = null;
 let selectedSystemOnMapId = null; // NEW: Tracks selected system for map actions
 let currentMapScale = 1;
 
+let isAdminMode = false;
+
 let isPanning = false;
 let wasDragged = false;
 let startX, scrollLeftStart;
@@ -69,6 +71,16 @@ function showNotification(message, type = 'info', duration = 5000) {
         clearTimeout(timer);
         hideNotif();
     });
+}
+
+function updateAdminModeUI() {
+    document.querySelectorAll('.tally-btn').forEach(btn => {
+        btn.disabled = !isAdminMode;
+    });
+    const toggleBtn = document.getElementById('toggle-admin-btn');
+    if (toggleBtn) {
+        toggleBtn.textContent = isAdminMode ? 'Mode Utilisateur' : 'Mode Admin';
+    }
 }
 
 /**

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
                 <span>
                     <button id="back-to-system-btn" class="hidden" style="margin-right: 10px;">&larr; Retour au système</button>
                     <button id="back-to-list-btn">&larr; Retour à la liste</button>
+                    <button id="toggle-admin-btn" class="btn-secondary" style="margin-left: 10px;">Mode Admin</button>
                 </span>
             </div>
             <div class="player-info-grid">

--- a/main.js
+++ b/main.js
@@ -22,6 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const planetTypeForm = document.getElementById('planet-type-form');
     const backToListBtn = document.getElementById('back-to-list-btn');
     const backToSystemBtn = document.getElementById('back-to-system-btn');
+    const toggleAdminBtn = document.getElementById('toggle-admin-btn');
     const exportBtn = document.getElementById('export-btn');
     const importBtn = document.getElementById('import-btn');
     const importFile = document.getElementById('import-file');
@@ -81,7 +82,27 @@ document.addEventListener('DOMContentLoaded', () => {
             setTimeout(() => renderPlanetarySystem(currentlyViewedSystemId), 50);
         }
     });
-    
+
+    if (toggleAdminBtn) {
+        toggleAdminBtn.addEventListener('click', () => {
+            if (!isAdminMode) {
+                const pwd = prompt('Mot de passe admin:');
+                if (pwd !== 'warp') {
+                    showNotification('Mot de passe incorrect.', 'error');
+                    return;
+                }
+                isAdminMode = true;
+                showNotification('Mode Administrateur activé.', 'success');
+            } else {
+                isAdminMode = false;
+                showNotification('Mode Administrateur désactivé.', 'info');
+            }
+            updateAdminModeUI();
+        });
+    }
+
+    updateAdminModeUI();
+
     function handleModalClose(modal) {
         closeModal(modal);
     
@@ -250,7 +271,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.getElementById('player-detail-view').addEventListener('click', (e) => {
         const button = e.target.closest('.tally-btn');
-        if (!button || activePlayerIndex === -1) return;
+        if (!button || activePlayerIndex === -1 || !isAdminMode) return;
         const player = campaignData.players[activePlayerIndex];
         const action = button.dataset.action;
         if (button.id === 'increase-supply-limit-btn') return;

--- a/render.js
+++ b/render.js
@@ -139,6 +139,7 @@ const renderPlayerDetail = () => {
     document.getElementById('goals-notes').value = player.goalsNotes || '';
 
     renderOrderOfBattle();
+    if (typeof updateAdminModeUI === 'function') updateAdminModeUI();
 };
 
 

--- a/style.css
+++ b/style.css
@@ -94,6 +94,11 @@ button:hover, .btn-primary:hover {
     background-color: #c0953c;
 }
 
+button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 button.btn-secondary, .btn-secondary {
     background-color: #555;
     border-color: #333;


### PR DESCRIPTION
## Summary
- Require admin password to modify roster stats
- Add toggle button to switch between admin and user modes
- Disable tally buttons and style them when admin mode is off

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68976d4c635c8332af42ff9d4caa9fe7