### PR TITLE
Affiche le coût des optimisations de l'Ombre

### DIFF
--- a/upgrades.js
+++ b/upgrades.js
@@ -271,7 +271,7 @@ const populateUpgradeSelectors = () => {
         const legionSelect = document.getElementById('legion-of-shadow-select');
         legionSelect.innerHTML = '<option value="">Choisir une optimisation...</option>';
         chaosDaemonsCrusadeRules.legionOfShadowEnhancements.forEach(enhancement => {
-            legionSelect.innerHTML += `<option value="${enhancement.name}" data-cost="${enhancement.cost}" data-cp-cost="${enhancement.crusadePointCost}">${enhancement.name}</option>`;
+            legionSelect.innerHTML += `<option value="${enhancement.name}" data-cost="${enhancement.cost}" data-cp-cost="${enhancement.crusadePointCost}">${enhancement.name} (${enhancement.cost} PR)</option>`;
         });
     } else {
         legionOfShadowSection.classList.add('hidden');


### PR DESCRIPTION
## Summary
- Affiche le coût en points de réquisition pour les optimisations de l'Ombre des Démons du Chaos

## Testing
- `npm test` *(échoue: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68977b91e3d083329e8bc3345360f173