### PR TITLE
feat: Implement Agri-World and Forge-World bonuses

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,11 @@
                         <button id="increase-supply-limit-btn" class="tally-btn" title="Augmenter la limite de 200 PL pour 1 RP" style="margin-left: auto;">+200</button>
                     </div>
                 </div>
+                <div class="info-box" id="vehicle-monster-limit-box">
+                    <strong>Limite Véhicules/Monstres:</strong>
+                    <span id="vehicle-monster-limit-display" class="stat-value" style="color: var(--friendly-color);">30%</span>
+                    <small>Votre armée peut contenir 30% de Véhicules/Monstres du "Limite de Ravitaillement"</small>
+                </div>
                 <div class="info-box">
                     <strong>Coût Optimisations:</strong> <span id="upgrade-supply-cost" class="stat-value">0</span> pts
                 </div>

--- a/main.js
+++ b/main.js
@@ -229,7 +229,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 goalsNotes: '', units: [],
                 discoveredSystemIds: [newSystemId],
                 probedSystemIds: [],
-                actionLog: []
+                actionLog: [],
+                lastRpBonusTimestamp: null
             };
 
             if (faction === 'Adepta Sororitas') {


### PR DESCRIPTION
This commit introduces two new features based on planet ownership:

1.  **Agri-World Weekly RP Bonus:**
    - Players now receive +1 Requisition Point for each Agri-World they own, awarded automatically every 7 real-world days.
    - This is handled by adding a `lastRpBonusTimestamp` to the player object and a checking function that runs when the player's detail view is rendered.

2.  **Forge-World Vehicle/Monster Limit Bonus:**
    - A UI element now displays the percentage of a player's army that can be composed of Vehicles/Monsters.
    - The base limit is 30%, and this is increased by +10% for each Forge-World the player owns.
    - The display dynamically updates to reflect the current bonus (e.g., "40% (30% + 10%)").

These changes involve updates to the core game engine, rendering logic, player data structure, and the main HTML file.