### PR TITLE
This commit introduces a new modal window in the "System" view that d…

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -38,6 +38,8 @@ let wasDragged = false;
 let startX, scrollLeftStart;
 let startY, scrollTopStart;
 
+let bonusModalTimer = null;
+
 const STEP_DISTANCE = 250;
 const GALAXY_SIZE = 9;
 

--- a/index.html
+++ b/index.html
@@ -409,6 +409,7 @@
             <h3 id="world-modal-title" class="crusade-card-title">Système Planétaire</h3>
             <button id="show-history-btn" class="btn-secondary" style="margin-bottom: 15px;">Historique Complet</button>
             <button id="show-map-btn" class="btn-secondary" style="margin-bottom: 15px;">Voir la Carte Galactique</button>
+            <button id="show-bonus-btn" class="btn-secondary" style="margin-bottom: 15px;">État des Bonus Planétaires</button>
             <button id="edit-crusade-order-btn" class="btn-primary" style="margin-bottom: 15px;">Éditer l'Ordre de Croisade</button>
             <div id="system-container">
                 <button class="explore-arrow" id="explore-up" title="Explorer vers le Nord">↑</button>
@@ -758,5 +759,15 @@
     <script src="render.js"></script>
     <script src="upgrades.js"></script>
     <script src="main.js"></script>
+
+    <div id="planet-bonus-modal" class="modal hidden">
+        <div class="modal-content">
+            <span class="close-btn">&times;</span>
+            <h3 id="planet-bonus-modal-title">État des Bonus Planétaires</h3>
+            <div id="planet-bonus-content" style="padding-top: 15px;">
+                <!-- Le contenu sera généré par JavaScript -->
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -35,6 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const npcCombatModal = document.getElementById('npc-combat-modal');
     const pvpCombatModal = document.getElementById('pvp-combat-modal');
     const rulesModal = document.getElementById('rules-modal');
+    const planetBonusModal = document.getElementById('planet-bonus-modal');
     
     const actionLogContainer = document.getElementById('action-log-container');
     const actionLogHeader = document.getElementById('action-log-header');
@@ -115,6 +116,10 @@ document.addEventListener('DOMContentLoaded', () => {
             const previouslySelected = document.querySelector('.system-node.selected-for-action');
             if(previouslySelected) previouslySelected.classList.remove('selected-for-action');
             selectedSystemOnMapId = null; 
+        }
+        if (modal === planetBonusModal && bonusModalTimer) {
+            clearInterval(bonusModalTimer);
+            bonusModalTimer = null;
         }
     }
 
@@ -752,6 +757,9 @@ document.addEventListener('DOMContentLoaded', () => {
             setTimeout(renderGalacticMap, 50);
         } else if (e.target.id === 'show-history-btn') {
             openFullHistoryModal();
+        } else if (e.target.id === 'show-bonus-btn') {
+            renderPlanetBonusModal();
+            openModal(planetBonusModal);
         } else if (e.target.id === 'edit-crusade-order-btn') {
             const system = campaignData.systems.find(s => s.id === currentlyViewedSystemId);
             if (system && system.owner !== 'npc') {

--- a/style.css
+++ b/style.css
@@ -1211,3 +1211,36 @@ label {
     font-size: 1.2em;
     line-height: 1.2;
 }
+
+/* --- Styles for Planet Bonus Modal --- */
+.bonus-section {
+    margin-bottom: 15px;
+    padding-bottom: 15px;
+}
+
+.bonus-section:not(:last-child) {
+    border-bottom: 1px solid var(--border-color);
+}
+
+.bonus-section h4 {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin: 0 0 10px 0;
+    color: var(--primary-color);
+}
+
+.bonus-section p {
+    margin: 5px 0 5px 28px; /* Indent to align with text after icon */
+    color: var(--text-muted-color);
+}
+
+.bonus-section p strong {
+    color: var(--text-color);
+    font-weight: bold;
+}
+
+#agri-world-timer {
+    color: var(--warning-color);
+    font-weight: bold;
+}


### PR DESCRIPTION
…isplays the status of planetary bonuses for the current player.

The modal shows:
- The total bonus to the Vehicle/Monster limit from controlled Forge Worlds.
- The weekly Requisition Point bonus from controlled Agri-worlds.
- A real-time countdown timer indicating when the next Agri-world bonus will be awarded.

This feature provides players with a clear and easily accessible overview of their planetary income, as requested.