### PR TITLE
feat: Display galaxy format and fix modal z-index

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
             </p>
             <div class="management-controls">
                 <button id="reset-campaign-btn" class="btn-danger">Explosion du Warp (Réinitialiser)</button>
+                <span id="galaxy-format-display" style="color: var(--text-muted-color); align-self: center;"></span>
                 </div>
         </header>
 

--- a/main.js
+++ b/main.js
@@ -1691,4 +1691,12 @@ document.addEventListener('DOMContentLoaded', () => {
             showNotification(notificationMessage, 'success', 7000);
         }
     });
+
+    function updateGalaxyFormatDisplay() {
+        const displayElement = document.getElementById('galaxy-format-display');
+        if (displayElement) {
+            displayElement.textContent = `Format de la galaxie: ${GALAXY_SIZE}x${GALAXY_SIZE}`;
+        }
+    }
+    updateGalaxyFormatDisplay();
 });

--- a/style.css
+++ b/style.css
@@ -1025,6 +1025,10 @@ label {
 
 
 /* --- NOUVEAU : Infobulle personnalisée --- */
+#confirm-modal, #password-confirm-modal {
+    z-index: 1050;
+}
+
 #custom-tooltip {
     position: fixed;
     z-index: 1002; /* Doit être au-dessus des modales (z-index: 100) */


### PR DESCRIPTION
This commit introduces two changes based on user feedback:

1.  The galaxy format (e.g., 9x9) is now displayed on the main page, next to the 'Explosion du Warp (Réinitialiser)' button. This provides users with immediate information about the current campaign's map size.

2.  The z-index of the confirmation modals (`#confirm-modal` and `#password-confirm-modal`) has been increased to ensure they always appear in the foreground, above other UI elements.