### PR TITLE
Allow custom galaxy size and planet weights on reset

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -41,7 +41,15 @@ let startY, scrollTopStart;
 let bonusModalTimer = null;
 
 const STEP_DISTANCE = 250;
-const GALAXY_SIZE = 9;
+let GALAXY_SIZE = 9;
+let planetTypeWeights = {
+    "Monde Ruche": 38,
+    "Agri-monde": 25,
+    "Monde Sauvage": 15,
+    "Monde Mort": 10,
+    "Monde Forge": 10,
+    "Monde Saint (relique)": 2
+};
 
 //======================================================================
 //  SYSTÈME DE NOTIFICATION, CONFIRMATION, LOG & MODALES
@@ -718,6 +726,25 @@ const migrateData = () => {
         campaignData.sessionLog = [];
         dataWasModified = true;
     }
+
+    if (campaignData.galaxySize === undefined) {
+        campaignData.galaxySize = 9;
+        dataWasModified = true;
+    }
+    GALAXY_SIZE = campaignData.galaxySize;
+
+    if (!campaignData.planetWeights) {
+        campaignData.planetWeights = {
+            "Monde Ruche": 38,
+            "Agri-monde": 25,
+            "Monde Sauvage": 15,
+            "Monde Mort": 10,
+            "Monde Forge": 10,
+            "Monde Saint (relique)": 2
+        };
+        dataWasModified = true;
+    }
+    planetTypeWeights = campaignData.planetWeights;
 
     // Ancienne fonction pour la compatibilité de `discoveredSystemIds`
     const oldGetReachableSystems = (startSystemId) => {

--- a/galaxy.js
+++ b/galaxy.js
@@ -3,18 +3,9 @@
 //======================================================================
 
 const getWeightedRandomPlanetType = () => {
-    const types = [
-        { name: "Monde Ruche", weight: 38 },
-        { name: "Agri-monde", weight: 25 },
-        { name: "Monde Sauvage", weight: 15 },
-        { name: "Monde Mort", weight: 10 },
-        { name: "Monde Forge", weight: 10 },
-        { name: "Monde Saint (relique)", weight: 2 }
-    ];
-
+    const types = Object.entries(planetTypeWeights).map(([name, weight]) => ({ name, weight }));
     const totalWeight = types.reduce((sum, type) => sum + type.weight, 0);
     let random = Math.random() * totalWeight;
-
     for (const type of types) {
         if (random < type.weight) {
             return type.name;


### PR DESCRIPTION
## Summary
- Let admins configure galaxy size and planet type probabilities during Warp reset
- Preserve player home systems after Warp explosion and reset their map discovery
- Store and load configurable galaxy settings from campaign data

## Testing
- ⚠️ `npm test` (no tests specified)


------
https://chatgpt.com/codex/tasks/task_e_68a065f25cdc8332bd2441587d9e6357