### PR TITLE
feat: stylized warp settings modal

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -235,7 +235,54 @@ function showPasswordConfirm(title, text) {
         confirmModalInput.addEventListener('keydown', keydownListener);
 
         // Focus the input field when the modal opens
-        setTimeout(() => confirmModalInput.focus(), 100);
+    setTimeout(() => confirmModalInput.focus(), 100);
+    });
+}
+
+
+function showWarpSettingsModal(currentSize, currentWeights) {
+    return new Promise(resolve => {
+        const modal = document.getElementById('warp-settings-modal');
+        const sizeInput = document.getElementById('warp-galaxy-size');
+        const weightsContainer = document.getElementById('warp-planet-weights');
+        const okBtn = document.getElementById('warp-settings-ok-btn');
+        const cancelBtn = document.getElementById('warp-settings-cancel-btn');
+
+        sizeInput.value = currentSize;
+        weightsContainer.innerHTML = '';
+        Object.entries(currentWeights).forEach(([type, weight]) => {
+            const div = document.createElement('div');
+            div.className = 'form-group';
+            div.innerHTML = `<label>${type}</label><input type="number" data-type="${type}" value="${weight}" min="0" max="100">`;
+            weightsContainer.appendChild(div);
+        });
+
+        openModal(modal);
+
+        const closeAndResolve = (result) => {
+            closeModal(modal);
+            okBtn.removeEventListener('click', okListener);
+            cancelBtn.removeEventListener('click', cancelListener);
+            modal.querySelector('.close-btn').removeEventListener('click', cancelListener);
+            resolve(result);
+        };
+
+        const okListener = () => {
+            const newSize = parseInt(sizeInput.value);
+            const newWeights = {};
+            weightsContainer.querySelectorAll('input').forEach(input => {
+                const t = input.dataset.type;
+                const val = parseInt(input.value);
+                newWeights[t] = isNaN(val) ? currentWeights[t] : val;
+            });
+            closeAndResolve({ size: isNaN(newSize) ? currentSize : newSize, weights: newWeights });
+        };
+
+        const cancelListener = () => closeAndResolve(null);
+
+        okBtn.addEventListener('click', okListener);
+        cancelBtn.addEventListener('click', cancelListener);
+        modal.querySelector('.close-btn').addEventListener('click', cancelListener);
     });
 }
 

--- a/index.html
+++ b/index.html
@@ -653,6 +653,22 @@
             </div>
         </div>
     </div>
+    
+    <div id="warp-settings-modal" class="modal hidden">
+        <div class="modal-content warhammer">
+            <span class="close-btn">&times;</span>
+            <h3>Rite de Cartographie</h3>
+            <div class="form-group">
+                <label for="warp-galaxy-size">Taille de la Galaxie</label>
+                <input type="number" id="warp-galaxy-size" min="1">
+            </div>
+            <div id="warp-planet-weights"></div>
+            <div class="modal-actions">
+                <button id="warp-settings-cancel-btn" class="btn-secondary">Annuler</button>
+                <button id="warp-settings-ok-btn" class="btn-danger">Confirmer</button>
+            </div>
+        </div>
+    </div>
 
     <div id="plague-management-modal" class="modal hidden">
         <div class="modal-content large">

--- a/main.js
+++ b/main.js
@@ -1110,21 +1110,17 @@ document.addEventListener('DOMContentLoaded', () => {
             "Êtes-vous sûr ? Cette action va générer une <b>nouvelle carte galactique</b> et réinitialiser la position de TOUS les joueurs. Leurs fiches de personnage (unités, points, etc.) seront conservées.<br><br><b>Pour confirmer, entrez le mot de passe ci-dessous.</b>"
         );
         if (confirmReset) {
-            const sizeInput = prompt("Dimension de la galaxie (taille d'un côté)", GALAXY_SIZE);
-            const newSize = parseInt(sizeInput);
-            if (!isNaN(newSize) && newSize > 0) {
-                GALAXY_SIZE = newSize;
-                campaignData.galaxySize = newSize;
-                updateGalaxyFormatDisplay();
+            const settings = await showWarpSettingsModal(GALAXY_SIZE, planetTypeWeights);
+            if (settings) {
+                const newSize = parseInt(settings.size);
+                if (!isNaN(newSize) && newSize > 0) {
+                    GALAXY_SIZE = newSize;
+                    campaignData.galaxySize = newSize;
+                    updateGalaxyFormatDisplay();
+                }
+                planetTypeWeights = settings.weights;
+                campaignData.planetWeights = settings.weights;
             }
-
-            const newWeights = {};
-            Object.entries(planetTypeWeights).forEach(([type, weight]) => {
-                const input = parseInt(prompt(`% de ${type}`, weight));
-                newWeights[type] = isNaN(input) ? weight : input;
-            });
-            planetTypeWeights = newWeights;
-            campaignData.planetWeights = newWeights;
 
             const playerSystemIds = new Set(campaignData.players.map(p => p.systemId));
             const playerSystems = campaignData.systems.filter(s => playerSystemIds.has(s.id));

--- a/style.css
+++ b/style.css
@@ -884,6 +884,31 @@ label {
     margin-top: 20px;
 }
 
+/* --- Modal Explosion du Warp --- */
+#warp-settings-modal .modal-content.warhammer {
+    background-color: #1a0f0f;
+    border: 4px solid var(--danger-color);
+    box-shadow: 0 0 25px var(--danger-color);
+    font-family: 'Cinzel', serif;
+}
+
+#warp-settings-modal h3 {
+    color: var(--danger-color);
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+#warp-planet-weights .form-group {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+#warp-planet-weights input {
+    width: 80px;
+}
+
 /* --- NOUVEAU : Notifications Stylisées --- */
 #notification-container {
     position: fixed;


### PR DESCRIPTION
## Summary
- add Warhammer-styled modal to configure galaxy size and planet type distribution during Warp Explosion
- replace console prompts with modal-driven settings
- style new modal with dark Mechanicus theme

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a06a42b0948332af7e67c4d414b8f9