### PR TITLE
Ensure warp settings confirm requires full planet distribution

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -247,6 +247,7 @@ function showWarpSettingsModal(currentSize, currentWeights) {
         const weightsContainer = document.getElementById('warp-planet-weights');
         const okBtn = document.getElementById('warp-settings-ok-btn');
         const cancelBtn = document.getElementById('warp-settings-cancel-btn');
+        const totalDisplay = document.getElementById('warp-planet-total-value');
 
         sizeInput.value = currentSize;
         weightsContainer.innerHTML = '';
@@ -256,6 +257,21 @@ function showWarpSettingsModal(currentSize, currentWeights) {
             div.innerHTML = `<label>${type}</label><input type="number" data-type="${type}" value="${weight}" min="0" max="100">`;
             weightsContainer.appendChild(div);
         });
+
+        const updateTotal = () => {
+            let total = 0;
+            weightsContainer.querySelectorAll('input').forEach(input => {
+                total += parseInt(input.value) || 0;
+            });
+            totalDisplay.textContent = total;
+            okBtn.disabled = total !== 100;
+        };
+
+        weightsContainer.querySelectorAll('input').forEach(input => {
+            input.addEventListener('input', updateTotal);
+        });
+
+        updateTotal();
 
         openModal(modal);
 

--- a/index.html
+++ b/index.html
@@ -663,6 +663,7 @@
                 <input type="number" id="warp-galaxy-size" min="1">
             </div>
             <div id="warp-planet-weights"></div>
+            <div id="warp-planet-total">Total: <span id="warp-planet-total-value">0</span>%</div>
             <div class="modal-actions">
                 <button id="warp-settings-cancel-btn" class="btn-secondary">Annuler</button>
                 <button id="warp-settings-ok-btn" class="btn-danger">Confirmer</button>

--- a/style.css
+++ b/style.css
@@ -909,6 +909,12 @@ label {
     width: 80px;
 }
 
+#warp-planet-total {
+    text-align: right;
+    font-weight: bold;
+    margin-top: 10px;
+}
+
 /* --- NOUVEAU : Notifications Stylisées --- */
 #notification-container {
     position: fixed;


### PR DESCRIPTION
## Summary
- Display running total of planet type percentages in Rite de Cartographie settings modal.
- Disable Confirm button until planet percentages total 100%.
- Style total percentage display for clarity.

## Testing
- `node --check engine.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a06c98e1ec8332a3f7aa6fb323e159