### PR TITLE
Affiche infos supplémentaires des joueurs

### DIFF
--- a/render.js
+++ b/render.js
@@ -54,7 +54,10 @@ const renderPlayerList = () => {
             <p>
                 ${player.faction || 'Faction non spécifiée'}<br>
                 Statut: ${onMapStatus}<br>
-                Parties: ${totalGames} (PNJ: ${npcGames})
+                Parties: ${totalGames} (PNJ: ${npcGames})<br>
+                Sondes gratuites: ${player.freeProbes || 0}<br>
+                Limite de Ravitaillement: ${player.supplyLimit || 0} PL<br>
+                RP disponibles: ${player.requisitionPoints || 0}
             </p>
             <div class="player-card-actions">
                 <button class="btn-secondary edit-player-btn" data-index="${index}">Modifier</button>


### PR DESCRIPTION
## Summary
- Affiche dans la liste des joueurs les sondes gratuites, la limite de ravitaillement et les RP disponibles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0725314708332a0a7e4caea50fa83