### PR TITLE
Reduce player territory stats text size

### DIFF
--- a/render.js
+++ b/render.js
@@ -71,7 +71,7 @@ const renderPlayerList = () => {
         const { planetCount, systemCount } = getPlayerTerritoryStats(player.id);
 
         card.innerHTML = `
-            <h3 class="player-name-link" data-index="${index}">${player.name} (${planetCount} planètes / ${systemCount} systèmes)</h3>
+            <h3 class="player-name-link" data-index="${index}">${player.name} <span class="player-territory-stats">(${planetCount} planètes / ${systemCount} systèmes)</span></h3>
             <p>
                 ${player.faction || 'Faction non spécifiée'}<br>
                 Statut: ${onMapStatus}<br>

--- a/style.css
+++ b/style.css
@@ -203,6 +203,11 @@ label {
     cursor: pointer;
 }
 
+.player-card h3 .player-territory-stats {
+    font-size: 0.8em;
+    font-weight: normal;
+}
+
 .player-card p {
     margin: 0 0 10px 0;
     color: var(--text-muted-color);


### PR DESCRIPTION
## Summary
- Display player territory stats in smaller font

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a0767c28ac8332977a3bd36331d3f9