### PR TITLE
Handle pluralization of planet and system counts

### DIFF
--- a/galaxy.js
+++ b/galaxy.js
@@ -73,7 +73,8 @@ const generateGalaxy = () => {
     
     campaignData.systems = newSystems;
     campaignData.isGalaxyGenerated = true;
-    showNotification(`Galaxie de <b>${newSystems.length}</b> systèmes PNJ créée.`, 'success');
+    const systemLabel = newSystems.length > 1 ? 'systèmes' : 'système';
+    showNotification(`Galaxie de <b>${newSystems.length}</b> ${systemLabel} PNJ créée.`, 'success');
 };
 
 /**

--- a/render.js
+++ b/render.js
@@ -69,9 +69,11 @@ const renderPlayerList = () => {
         const totalGames = (player.battles.wins || 0) + (player.battles.losses || 0);
         const npcGames = player.battles.npcGames || 0;
         const { planetCount, systemCount } = getPlayerTerritoryStats(player.id);
+        const planetLabel = planetCount > 1 ? 'planètes' : 'planète';
+        const systemLabel = systemCount > 1 ? 'systèmes' : 'système';
 
         card.innerHTML = `
-            <h3 class="player-name-link" data-index="${index}">${player.name} <span class="player-territory-stats">(${planetCount} planètes / ${systemCount} systèmes)</span></h3>
+            <h3 class="player-name-link" data-index="${index}">${player.name} <span class="player-territory-stats">(${planetCount} ${planetLabel} / ${systemCount} ${systemLabel})</span></h3>
             <p>
                 ${player.faction || 'Faction non spécifiée'}<br>
                 Statut: ${onMapStatus}<br>


### PR DESCRIPTION
## Summary
- Ensure player cards pluralize `planète` and `système` only when counts exceed one
- Pluralize galaxy generation message for the number of NPC systems

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a07989def88332b01ffc7c2c03ff0a