### PR TITLE
Fix roster view lost after closing system window

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -30,6 +30,7 @@ let currentlyViewedSystemId = null;
 let mapViewingPlayerId = null;
 let selectedSystemOnMapId = null; // NEW: Tracks selected system for map actions
 let currentMapScale = 1;
+let returnToPlayerDetailAfterWorldModal = false;
 
 let isAdminMode = false;
 

--- a/main.js
+++ b/main.js
@@ -154,6 +154,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     backToSystemBtn.addEventListener('click', () => {
         if (currentlyViewedSystemId) {
+            returnToPlayerDetailAfterWorldModal = true;
             playerDetailView.classList.add('hidden');
             openModal(worldModal);
             setTimeout(() => renderPlanetarySystem(currentlyViewedSystemId), 50);
@@ -182,16 +183,20 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function handleModalClose(modal) {
         closeModal(modal);
-    
+
         if (modal === worldModal) {
-            mapViewingPlayerId = null; 
+            mapViewingPlayerId = null;
             renderActionLog();
             renderPlayerList();
+            if (returnToPlayerDetailAfterWorldModal) {
+                playerDetailView.classList.remove('hidden');
+                returnToPlayerDetailAfterWorldModal = false;
+            }
         }
         if (modal === mapModal) {
             const previouslySelected = document.querySelector('.system-node.selected-for-action');
             if(previouslySelected) previouslySelected.classList.remove('selected-for-action');
-            selectedSystemOnMapId = null; 
+            selectedSystemOnMapId = null;
         }
         if (modal === planetBonusModal && bonusModalTimer) {
             clearInterval(bonusModalTimer);
@@ -239,6 +244,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const playerIndex = parseInt(target.dataset.index);
             const player = campaignData.players[playerIndex];
             if (player.systemId) {
+                returnToPlayerDetailAfterWorldModal = false;
                 activePlayerIndex = playerIndex;
                 mapViewingPlayerId = player.id;
                 openModal(worldModal);
@@ -1067,6 +1073,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
                 if (systemId) {
                     closeModal(mapModal);
+                    returnToPlayerDetailAfterWorldModal = false;
                     openModal(worldModal);
                     setTimeout(() => renderPlanetarySystem(systemId), 50);
                 }


### PR DESCRIPTION
## Summary
- Keep track of when the system modal is opened from a roster
- Restore the roster view when closing the system modal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a07c642b548332b37ec5d6a78a70fb