### PR TITLE
feat: add post-battle roster update modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -586,6 +586,23 @@
     </div>
 
 
+    <div id="post-battle-modal" class="modal hidden">
+        <div class="modal-content large">
+            <span class="close-btn">&times;</span>
+            <h3 class="crusade-card-title">Résultats de Bataille</h3>
+            <div id="post-battle-units"></div>
+            <div class="form-group" style="margin-top:15px;">
+                <label for="mark-honor-select">Mettre en Honneur :</label>
+                <select id="mark-honor-select">
+                    <option value="">-- Choisir une unité --</option>
+                </select>
+            </div>
+            <div class="modal-actions">
+                <button id="post-battle-save-btn" class="btn-primary">Enregistrer</button>
+            </div>
+        </div>
+    </div>
+
     <div id="notification-container"></div>
     
     <div id="action-log-container" class="action-log">

--- a/style.css
+++ b/style.css
@@ -1284,3 +1284,25 @@ label {
     color: var(--warning-color);
     font-weight: bold;
 }
+
+/* --- Post-battle modal styles --- */
+.post-battle-unit {
+    border-bottom: 1px solid var(--border-color);
+    padding: 10px 0;
+}
+
+.post-battle-unit h4 {
+    margin: 0 0 5px 0;
+}
+
+.post-battle-unit label {
+    margin-right: 10px;
+}
+
+.post-battle-unit .roll-btn {
+    margin-left: 5px;
+}
+
+.post-battle-unit .scar-select {
+    margin-left: 5px;
+}


### PR DESCRIPTION
## Summary
- add modal to process roster effects after NPC combat
- record participation XP, kills, destruction scars and mark of honour
- style for new post-battle interface

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a71f66f0833298466a1602475b57