### PR TITLE
feat: nickname column and rank-up optimization alert

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,7 @@
                 <thead>
                     <tr>
                         <th>Nom de l'Unité</th>
+                        <th>Surnom</th>
                         <th>Rôle</th>
                         <th>Coût en Points</th>
                         <th>Points de Croisade</th>
@@ -259,11 +260,15 @@
             <form id="unit-form">
                 <input type="hidden" id="unit-id">
                 <div class="unit-card-header">
-                     <div class="form-group">
+                    <div class="form-group">
                         <label for="unit-name">Nom de l'unité :</label>
                         <select id="unit-name" required>
                             <option value="" disabled selected>Choisir une unité...</option>
                         </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="unit-nickname">Surnom :</label>
+                        <input type="text" id="unit-nickname">
                     </div>
                 </div>
 

--- a/main.js
+++ b/main.js
@@ -194,6 +194,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             const newRank = getRankFromXp(unit.xp);
             if (newRank !== getRankFromXp(prevXp)) {
+                unit.pendingOptimization = true;
                 showNotification(`${unit.name} atteint le rang ${newRank} ! Trait ou Relique (1 PR) disponible.`, 'info');
             }
         });
@@ -208,6 +209,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 logAction(player.id, `<b>${honouredUnit.name}</b> a été mis à l'honneur (+3 XP).`, 'info', '🏅');
                 const newRank = getRankFromXp(honouredUnit.xp);
                 if (newRank !== getRankFromXp(prevXp)) {
+                    honouredUnit.pendingOptimization = true;
                     showNotification(`${honouredUnit.name} atteint le rang ${newRank} ! Trait ou Relique (1 PR) disponible.`, 'info');
                 }
             }
@@ -694,6 +696,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const player = campaignData.players[activePlayerIndex];
         const unitData = {
             name: name,
+            nickname: document.getElementById('unit-nickname').value,
             role: document.getElementById('unit-role').value,
             power: parseInt(document.getElementById('unit-power').value) || 0,
             xp: parseInt(document.getElementById('unit-xp').value) || 0,
@@ -706,6 +709,11 @@ document.addEventListener('DOMContentLoaded', () => {
             markedForGlory: parseInt(document.getElementById('unit-marked-for-glory').value) || 0
         };
         const existingUnit = player.units[editingUnitIndex];
+        const prevRank = getRankFromXp(existingUnit.xp || 0);
+        const newRank = getRankFromXp(unitData.xp);
+        if (newRank !== prevRank) {
+            unitData.pendingOptimization = true;
+        }
         player.units[editingUnitIndex] = { ...existingUnit, ...unitData };
         saveData();
         renderPlayerDetail();
@@ -719,6 +727,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const player = campaignData.players[activePlayerIndex];
         const unitData = {
             name: name,
+            nickname: document.getElementById('unit-nickname').value,
             role: document.getElementById('unit-role').value,
             power: parseInt(document.getElementById('unit-power').value) || 0,
             xp: parseInt(document.getElementById('unit-xp').value) || 0,
@@ -730,13 +739,19 @@ document.addEventListener('DOMContentLoaded', () => {
             battleScars: document.getElementById('unit-scars').value,
             markedForGlory: parseInt(document.getElementById('unit-marked-for-glory').value) || 0
         };
-    
+
         if (editingUnitIndex > -1) {
             const existingUnit = player.units[editingUnitIndex];
+            const prevRank = getRankFromXp(existingUnit.xp || 0);
+            const newRank = getRankFromXp(unitData.xp);
+            if (newRank !== prevRank) {
+                unitData.pendingOptimization = true;
+            }
             player.units[editingUnitIndex] = { ...existingUnit, ...unitData };
         } else {
             unitData.id = crypto.randomUUID();
             unitData.detachmentUpgrades = [];
+            unitData.pendingOptimization = false;
             player.units.push(unitData);
             logAction(player.id, `Nouvelle unité ajoutée à l'ordre de bataille : <b>${unitData.name}</b>.`, 'info', '➕');
         }

--- a/render.js
+++ b/render.js
@@ -222,13 +222,18 @@ const renderOrderOfBattle = () => {
             ? `${unit.name} <span class="doubled-indicator">x2</span>`
             : unit.name;
 
+        const rankCell = unit.pendingOptimization
+            ? `<span class="blink">${rank}</span> <span class="optimisation-disponible">(Optimisation disponible)</span>`
+            : rank;
+
         row.innerHTML = `
             <td>${displayName}</td>
+            <td>${unit.nickname || ''}</td>
             <td>${unit.role}</td>
             <td>${unit.power || 0}</td>
             <td>${unit.crusadePoints || 0}</td>
             <td>${unit.xp}</td>
-            <td>${rank}</td>
+            <td>${rankCell}</td>
             <td>
                 <button class="btn-secondary edit-unit-btn" data-index="${index}">Détails</button>
                 <button class="btn-danger delete-unit-btn" data-index="${index}">Supprimer</button>

--- a/style.css
+++ b/style.css
@@ -1306,3 +1306,18 @@ label {
 .post-battle-unit .scar-select {
     margin-left: 5px;
 }
+
+.blink {
+    animation: blink-animation 1s step-start 0s infinite;
+}
+
+@keyframes blink-animation {
+    50% { opacity: 0; }
+}
+
+.optimisation-disponible {
+    color: var(--danger-color);
+    font-weight: bold;
+    margin-left: 5px;
+    font-size: 0.9em;
+}

--- a/upgrades.js
+++ b/upgrades.js
@@ -285,13 +285,17 @@ const populateUpgradeSelectors = () => {
     }
 };
 
-const addUpgradeToUnitData = (unit, textareaId, upgradeName, upgradeDesc, prefix = '') => {
+const addUpgradeToUnitData = (unit, textareaId, upgradeName, upgradeDesc, prefix = '', isOptimization = true) => {
     const textToAdd = `\n- ${prefix}${upgradeName}: ${upgradeDesc}`;
     const key = textareaId.replace('unit-', '');
     const dataKey = key === 'honours' ? 'battleHonours' : (key === 'scars' ? 'battleScars' : key);
 
     unit[dataKey] = (unit[dataKey] || '').trim() + textToAdd;
     document.getElementById(textareaId).value = unit[dataKey];
+
+    if (isOptimization) {
+        unit.pendingOptimization = false;
+    }
 };
 
 
@@ -395,7 +399,7 @@ document.getElementById('add-battle-scar-btn').addEventListener('click', () => {
     const scarDesc = findUpgradeDescription(scarName);
     const unit = campaignData.players[activePlayerIndex].units[editingUnitIndex];
 
-    addUpgradeToUnitData(unit, 'unit-scars', scarName, scarDesc);
+    addUpgradeToUnitData(unit, 'unit-scars', scarName, scarDesc, '', false);
     saveData();
     
     select.value = '';


### PR DESCRIPTION
## Summary
- allow assigning unit nicknames and display them in Order of Battle
- flag units for optimization when they gain a new rank and highlight in roster
- add blinking rank indicator and clear flag when an upgrade is applied

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1aa92a3988332a494ee3589e20a84