### PR TITLE
Met à jour le compteur "Marqué pour la Gloire" avec les kills

### DIFF
--- a/main.js
+++ b/main.js
@@ -185,6 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             if (kills > 0) {
                 unit.kills = (unit.kills || 0) + kills;
+                unit.markedForGlory = (unit.markedForGlory || 0) + kills;
                 logAction(player.id, `<b>${unit.name}</b> a réalisé ${kills} destructions.`, 'info', '☠️');
             }
             if (destroyed && roll === 1 && scarName) {


### PR DESCRIPTION
## Résumé
- Incrémente `markedForGlory` de l'unité lors de l'attribution des kills dans les résultats de bataille.

## Tests
- `npm test` *(échoue : Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1adbffc90833291215cef49bf1ab8