### PR TITLE
Calcul de l'XP basé sur les kills et amélioration du résultat de bataille

### DIFF
--- a/main.js
+++ b/main.js
@@ -113,12 +113,14 @@ document.addEventListener('DOMContentLoaded', () => {
             unitDiv.dataset.unitId = unit.id;
             unitDiv.innerHTML = `
                 <h4>${unit.name}</h4>
-                <label><input type="checkbox" class="present-checkbox"> Présent</label>
-                <label>Kills: <input type="number" class="kills-input" min="0" value="0" style="width:60px;"></label>
-                <label><input type="checkbox" class="destroyed-checkbox"> Détruite</label>
-                <button type="button" class="roll-btn hidden">Jet D6</button>
-                <span class="roll-result" style="margin-left:5px;"></span>
-                <select class="scar-select hidden">${getBattleScarOptionsHtml(player)}</select>
+                <div class="post-battle-row">
+                    <label><input type="checkbox" class="present-checkbox" checked> Présent</label>
+                    <label>Kills: <input type="number" class="kills-input" min="0" value="0" style="width:60px;"></label>
+                    <label><input type="checkbox" class="destroyed-checkbox"> Détruite</label>
+                    <button type="button" class="roll-btn hidden">Jet D6</button>
+                    <span class="roll-result"></span>
+                    <select class="scar-select hidden">${getBattleScarOptionsHtml(player)}</select>
+                </div>
             `;
 
             const destroyedChk = unitDiv.querySelector('.destroyed-checkbox');
@@ -184,9 +186,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 logAction(player.id, `<b>${unit.name}</b> a participé à la bataille (+1 XP).`, 'info', '🎖️');
             }
             if (kills > 0) {
-                unit.kills = (unit.kills || 0) + kills;
+                const previousKills = unit.kills || 0;
+                unit.kills = previousKills + kills;
                 unit.markedForGlory = (unit.markedForGlory || 0) + kills;
                 logAction(player.id, `<b>${unit.name}</b> a réalisé ${kills} destructions.`, 'info', '☠️');
+
+                const prevBonusXp = Math.floor(previousKills / 3);
+                const newBonusXp = Math.floor(unit.kills / 3);
+                const bonusXp = newBonusXp - prevBonusXp;
+                if (bonusXp > 0) {
+                    unit.xp = (unit.xp || 0) + bonusXp;
+                    logAction(player.id, `<b>${unit.name}</b> gagne ${bonusXp} XP pour ses destructions.`, 'info', '⚔️');
+                }
             }
             if (destroyed && roll === 1 && scarName) {
                 const desc = findUpgradeDescription ? findUpgradeDescription(scarName) : '';

--- a/style.css
+++ b/style.css
@@ -1299,12 +1299,19 @@ label {
     margin-right: 10px;
 }
 
+.post-battle-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 10px;
+}
+
 .post-battle-unit .roll-btn {
-    margin-left: 5px;
+    margin-left: 0;
 }
 
 .post-battle-unit .scar-select {
-    margin-left: 5px;
+    margin-left: 0;
 }
 
 .blink {


### PR DESCRIPTION
## Résumé
- Ajout du calcul automatique d'XP pour chaque tranche de trois kills enregistrés après un combat
- Case "Présent" cochée par défaut et mise en page plus claire pour le résultat de bataille

## Test
- `npm test` *(échoue : Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b02c6f6483329e0e39ee7e63c881