### PR TITLE
feat: enhance battle results visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -592,9 +592,9 @@
 
 
     <div id="post-battle-modal" class="modal hidden">
-        <div class="modal-content large">
+        <div class="modal-content large battle-results">
             <span class="close-btn">&times;</span>
-            <h3 class="crusade-card-title">Résultats de Bataille</h3>
+            <h3 class="crusade-card-title"><span class="battle-icon">⚔️</span>Résultats de Bataille</h3>
             <div id="post-battle-units"></div>
             <div class="form-group" style="margin-top:15px;">
                 <label for="mark-honor-select">Mettre en Honneur :</label>

--- a/main.js
+++ b/main.js
@@ -112,11 +112,11 @@ document.addEventListener('DOMContentLoaded', () => {
             unitDiv.className = 'post-battle-unit';
             unitDiv.dataset.unitId = unit.id;
             unitDiv.innerHTML = `
-                <h4>${unit.name}</h4>
+                <h4><span class="unit-icon">✠</span>${unit.name}</h4>
                 <div class="post-battle-row">
-                    <label><input type="checkbox" class="present-checkbox" checked> Présent</label>
-                    <label>Kills: <input type="number" class="kills-input" min="0" value="0" style="width:60px;"></label>
-                    <label><input type="checkbox" class="destroyed-checkbox"> Détruite</label>
+                    <label class="present"><span class="icon">🛡️</span><input type="checkbox" class="present-checkbox" checked> Présent</label>
+                    <label class="kills"><span class="icon">⚔️</span>Kills: <input type="number" class="kills-input" min="0" value="0"></label>
+                    <label class="destroyed"><span class="icon">☠️</span><input type="checkbox" class="destroyed-checkbox"> Détruite</label>
                     <button type="button" class="roll-btn hidden">Jet D6</button>
                     <span class="roll-result"></span>
                     <select class="scar-select hidden">${getBattleScarOptionsHtml(player)}</select>

--- a/style.css
+++ b/style.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@700&display=swap');
 /* --- Police et Thème Général --- */
 :root {
     --primary-color: #a37c27; /* Or/Bronze */
@@ -1286,32 +1287,115 @@ label {
 }
 
 /* --- Post-battle modal styles --- */
+#post-battle-modal .modal-content.battle-results {
+    background: radial-gradient(circle at top, #2a2a2a 0%, #0d0d0d 100%);
+    color: var(--text-color);
+}
+
+#post-battle-modal .crusade-card-title {
+    font-family: 'Cinzel', serif;
+    color: var(--primary-color);
+    text-shadow: 0 0 10px #000, 0 0 15px rgba(163,124,39,0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+}
+
+#post-battle-modal .battle-icon {
+    font-size: 1.5em;
+    color: var(--primary-color);
+}
+
 .post-battle-unit {
-    border-bottom: 1px solid var(--border-color);
-    padding: 10px 0;
+    background: linear-gradient(145deg, #2e2e2e, #1a1a1a);
+    border: 2px solid var(--primary-color);
+    border-radius: 8px;
+    padding: 15px;
+    margin-bottom: 15px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.7), inset 0 0 5px rgba(255,215,0,0.1);
+    transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.post-battle-unit:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 0 15px rgba(163,124,39,0.7), inset 0 0 10px rgba(255,215,0,0.2);
 }
 
 .post-battle-unit h4 {
-    margin: 0 0 5px 0;
+    margin: 0 0 10px 0;
+    font-family: 'Cinzel', serif;
+    color: #f0e6d2;
+    display: flex;
+    align-items: center;
+    gap: 8px;
 }
 
-.post-battle-unit label {
-    margin-right: 10px;
+.post-battle-unit h4 .unit-icon {
+    font-size: 1.2em;
+    color: var(--primary-color);
 }
 
 .post-battle-row {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 10px;
+    gap: 15px;
+}
+
+.post-battle-row label {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    margin-right: 0;
+}
+
+.post-battle-row label .icon {
+    font-size: 1.2em;
+}
+
+.post-battle-row label.present .icon { color: var(--friendly-color); }
+.post-battle-row label.kills .icon { color: var(--primary-color); }
+.post-battle-row label.destroyed .icon { color: var(--danger-color); }
+
+.post-battle-row .kills-input {
+    width: 60px;
+    background: #000;
+    color: var(--text-color);
+    border: 1px solid var(--primary-color);
+    border-radius: 4px;
+    padding: 2px 4px;
 }
 
 .post-battle-unit .roll-btn {
     margin-left: 0;
+    background: var(--primary-color);
+    color: #000;
+    border: none;
+    padding: 5px 10px;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.2s;
+}
+
+.post-battle-unit .roll-btn:hover {
+    background: #c0953c;
+    transform: scale(1.05);
 }
 
 .post-battle-unit .scar-select {
     margin-left: 0;
+    background: #000;
+    color: var(--text-color);
+    border: 1px solid var(--primary-color);
+    border-radius: 4px;
+    padding: 4px;
+}
+
+.post-battle-unit .roll-result {
+    font-weight: bold;
+    color: var(--warning-color);
+    text-shadow: 0 0 5px rgba(255,204,0,0.8);
 }
 
 .blink {


### PR DESCRIPTION
## Summary
- Rework battle results modal with Warhammer 40K styled background, fonts, and hover effects
- Introduce thematic icons and improved unit layout for post-battle reporting

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b8611e808332b03619b0560e729b