### PR TITLE
style: revamped battle results unit list

### DIFF
--- a/main.js
+++ b/main.js
@@ -112,14 +112,31 @@ document.addEventListener('DOMContentLoaded', () => {
             unitDiv.className = 'post-battle-unit';
             unitDiv.dataset.unitId = unit.id;
             unitDiv.innerHTML = `
-                <h4><span class="unit-icon">✠</span>${unit.name}</h4>
-                <div class="post-battle-row">
-                    <label class="present"><span class="icon">🛡️</span><input type="checkbox" class="present-checkbox" checked> Présent</label>
-                    <label class="kills"><span class="icon">⚔️</span>Kills: <input type="number" class="kills-input" min="0" value="0"></label>
-                    <label class="destroyed"><span class="icon">☠️</span><input type="checkbox" class="destroyed-checkbox"> Détruite</label>
-                    <button type="button" class="roll-btn hidden">Jet D6</button>
-                    <span class="roll-result"></span>
-                    <select class="scar-select hidden">${getBattleScarOptionsHtml(player)}</select>
+                <div class="unit-header">
+                    <span class="unit-icon">✠</span>
+                    <h4>${unit.name}</h4>
+                </div>
+                <div class="post-battle-grid">
+                    <div class="stat-box present">
+                        <span class="icon">🛡️</span>
+                        <span>Présent</span>
+                        <input type="checkbox" class="present-checkbox" checked>
+                    </div>
+                    <div class="stat-box kills">
+                        <span class="icon">⚔️</span>
+                        <span>Kills</span>
+                        <input type="number" class="kills-input" min="0" value="0">
+                    </div>
+                    <div class="stat-box destroyed">
+                        <span class="icon">☠️</span>
+                        <span>Détruite</span>
+                        <input type="checkbox" class="destroyed-checkbox">
+                    </div>
+                    <div class="stat-box scar">
+                        <button type="button" class="roll-btn hidden">Jet D6</button>
+                        <span class="roll-result"></span>
+                        <select class="scar-select hidden">${getBattleScarOptionsHtml(player)}</select>
+                    </div>
                 </div>
             `;
 

--- a/style.css
+++ b/style.css
@@ -1322,49 +1322,67 @@ label {
     box-shadow: 0 0 15px rgba(163,124,39,0.7), inset 0 0 10px rgba(255,215,0,0.2);
 }
 
-.post-battle-unit h4 {
-    margin: 0 0 10px 0;
-    font-family: 'Cinzel', serif;
-    color: #f0e6d2;
+.post-battle-unit .unit-header {
     display: flex;
     align-items: center;
     gap: 8px;
+    margin: 0 0 10px 0;
 }
 
-.post-battle-unit h4 .unit-icon {
+.post-battle-unit .unit-header h4 {
+    margin: 0;
+    font-family: 'Cinzel', serif;
+    color: #f0e6d2;
+}
+
+.post-battle-unit .unit-header .unit-icon {
     font-size: 1.2em;
     color: var(--primary-color);
 }
 
-.post-battle-row {
+.post-battle-unit .post-battle-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 10px;
+}
+
+.post-battle-unit .stat-box {
+    background: rgba(0,0,0,0.3);
+    border: 1px solid rgba(163,124,39,0.2);
+    border-radius: 6px;
+    padding: 8px;
+    text-align: center;
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
     align-items: center;
-    gap: 15px;
+    justify-content: center;
+    gap: 4px;
 }
 
-.post-battle-row label {
-    display: flex;
-    align-items: center;
-    gap: 5px;
-    margin-right: 0;
+.post-battle-unit .stat-box .icon {
+    font-size: 1.4em;
 }
 
-.post-battle-row label .icon {
-    font-size: 1.2em;
-}
+.post-battle-unit .stat-box.present .icon { color: var(--friendly-color); }
+.post-battle-unit .stat-box.kills .icon { color: var(--primary-color); }
+.post-battle-unit .stat-box.destroyed .icon { color: var(--danger-color); }
 
-.post-battle-row label.present .icon { color: var(--friendly-color); }
-.post-battle-row label.kills .icon { color: var(--primary-color); }
-.post-battle-row label.destroyed .icon { color: var(--danger-color); }
-
-.post-battle-row .kills-input {
-    width: 60px;
+.post-battle-unit .stat-box input,
+.post-battle-unit .stat-box select {
+    margin-top: 4px;
     background: #000;
     color: var(--text-color);
     border: 1px solid var(--primary-color);
     border-radius: 4px;
     padding: 2px 4px;
+}
+
+.post-battle-unit .stat-box .kills-input {
+    width: 60px;
+}
+
+.post-battle-unit .stat-box.scar {
+    gap: 5px;
 }
 
 .post-battle-unit .roll-btn {


### PR DESCRIPTION
## Summary
- restyled post-battle results modal with unit header and stat grid
- added CSS stat boxes and grid layout for a polished battle results list

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ba5a3d3883328b36b125bfa5f6d6