### PR TITLE
feat: add hive world reinforcement bonus

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -153,6 +153,9 @@ function logAction(playerId, message, type, icon = '📜') {
 
     saveData();
 
+
+/**
+ * Supprime le bonus de Monde Ruche d'une unité associée à la planète donnée.
     if (typeof renderActionLog === 'function') {
         renderActionLog();
     }
@@ -713,6 +716,22 @@ function checkAndApplyWeeklyRpBonus(player) {
 
     saveData();
 }
+
+/**
+ * Supprime le bonus de Monde Ruche d'une unité associée à la planète donnée.
+ * @param {object} planet - La planète à vérifier.
+ */
+function removeHiveWorldBonus(planet) {
+    if (!planet || !planet.hiveBonusUnitId) return;
+    campaignData.players.forEach(p => {
+        const unit = (p.units || []).find(u => u.id === planet.hiveBonusUnitId);
+        if (unit) {
+            delete unit.hiveWorldPlanetId;
+        }
+    });
+    delete planet.hiveBonusUnitId;
+}
+
 
 /**
  * Calcule le bonus de limite de Véhicules/Monstres pour les Mondes Forges.

--- a/main.js
+++ b/main.js
@@ -185,7 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     postBattleModal.querySelector('.close-btn').addEventListener('click', () => closeModal(postBattleModal));
 
-    postBattleSaveBtn.addEventListener('click', () => {
+    postBattleSaveBtn.addEventListener('click', async () => {
         const player = campaignData.players.find(p => p.id === postBattleModal.dataset.playerId);
         if (!player) return;
 
@@ -257,6 +257,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (found) { planet = found; system = sys; break; }
             }
             if (planet && planet.pendingOwner === player.id) {
+                const oldOwner = planet.owner;
+                if (planet.hiveBonusUnitId && oldOwner !== player.id) {
+                    removeHiveWorldBonus(planet);
+                }
                 planet.owner = planet.pendingOwner;
                 delete planet.pendingOwner;
                 planet.defense = 0;
@@ -264,12 +268,25 @@ document.addEventListener('DOMContentLoaded', () => {
                     planet.agriWorldCaptureTimestamp = new Date().getTime();
                 }
                 logAction(player.id, `<b>Capture validée !</b> <b>${planet.name}</b> est désormais sous votre contrôle.`, 'conquest', '🏆');
+                if (planet.type === 'Monde Ruche' && !planet.hiveBonusUnitId) {
+                    const eligibleUnits = player.units.filter(u => u.role !== 'Personnage' && u.role !== 'Hero Epique');
+                    if (eligibleUnits.length > 0) {
+                        const selectedUnitId = await showUnitChoiceModal(\`Bonus de Monde Ruche - ${planet.name}\`, 'Sélectionnez une unité (hors Personnages) qui bénéficiera d'une réduction pour doubler son effectif.', eligibleUnits);
+                        if (selectedUnitId) {
+                            const selectedUnit = player.units.find(u => u.id === selectedUnitId);
+                            selectedUnit.hiveWorldPlanetId = planet.id;
+                            planet.hiveBonusUnitId = selectedUnitId;
+                            logAction(player.id, `<b>${getUnitDisplayName(selectedUnit)}</b> bénéficie du bonus de <b>${planet.name}</b>.`, 'info', '🐝');
+                        }
+                    } else {
+                        showNotification("Aucune unité non-personnage disponible pour le bonus de Monde Ruche.", 'warning');
+                    }
+                }
                 if (system) {
                     renderPlanetarySystem(system.id);
                 }
             }
         }
-
         saveData();
         renderPlayerDetail();
         closeModal(postBattleModal);
@@ -341,6 +358,38 @@ document.addEventListener('DOMContentLoaded', () => {
                     logAction(player.id, `La relique de <b>${planetToUpdate.name}</b> a été assignée à <b>${getUnitDisplayName(selectedUnit)}</b>.`, 'info', '✨');
                     saveData();
                     renderPlanetBonusModal(); // Refresh the modal to show the change
+                }
+        } else if (target.classList.contains('assign-hive-bonus-btn')) {
+            const planetId = target.dataset.planetId;
+            const player = campaignData.players.find(p => p.id === mapViewingPlayerId);
+            if (!player) return;
+            let planetToUpdate;
+            for (const system of campaignData.systems) {
+                const foundPlanet = system.planets.find(p => p.id === planetId);
+                if (foundPlanet) {
+                    planetToUpdate = foundPlanet;
+                    break;
+                }
+            }
+            if (!planetToUpdate) {
+                showNotification("Erreur : Planète non trouvée.", 'error');
+                return;
+            }
+            const eligibleUnits = player.units.filter(u => u.role !== 'Personnage' && u.role !== 'Hero Epique');
+            if (eligibleUnits.length === 0) {
+                showNotification("Aucune unité éligible dans votre Ordre de Bataille.", 'warning');
+                return;
+            }
+            const selectedUnitId = await showUnitChoiceModal(\`Choisir une unité pour ${planetToUpdate.name}\`, "Sélectionnez une unité (hors Personnages) pour lui attribuer ce bonus.", eligibleUnits);
+            if (selectedUnitId) {
+                const selectedUnit = player.units.find(u => u.id === selectedUnitId);
+                if (selectedUnit) {
+                    selectedUnit.hiveWorldPlanetId = planetToUpdate.id;
+                    planetToUpdate.hiveBonusUnitId = selectedUnit.id;
+                    logAction(player.id, \`Le bonus de <b>${planetToUpdate.name}</b> a été assigné à <b>${getUnitDisplayName(selectedUnit)}</b>.\`, 'info', '🐝');
+                    saveData();
+                    renderPlanetBonusModal();
+                    if (activePlayerIndex === campaignData.players.findIndex(p => p.id === player.id) && !playerDetailView.classList.contains('hidden')) renderPlayerDetail();
                 }
             }
         }
@@ -682,14 +731,21 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('double-unit-cost-btn').addEventListener('click', () => {
         const unitPowerInput = document.getElementById('unit-power');
         const currentCost = parseInt(unitPowerInput.value) || 0;
-        unitPowerInput.value = currentCost * 2;
-    
+        let multiplier = 2;
+        const unitId = document.getElementById('unit-id').value;
+        if (unitId) {
+            const player = campaignData.players[activePlayerIndex];
+            const unit = player.units.find(u => u.id === unitId);
+            if (unit && unit.hiveWorldPlanetId) {
+                multiplier = 1.5;
+            }
+        }
+        unitPowerInput.value = Math.ceil(currentCost * multiplier);
         const equipmentTextarea = document.getElementById('unit-equipment');
         const note = "\n- Effectif doublé.";
         if (!equipmentTextarea.value.includes(note)) {
             equipmentTextarea.value = (equipmentTextarea.value || '').trim() + note;
         }
-    
         unitPowerInput.dispatchEvent(new Event('change', { bubbles: true }));
         equipmentTextarea.dispatchEvent(new Event('change', { bubbles: true }));
     });
@@ -1075,8 +1131,12 @@ document.addEventListener('DOMContentLoaded', () => {
         const oldOwner = planet.owner;
     
         const newOwnerId = document.getElementById('planet-owner-select').value;
-        planet.type = document.getElementById('planet-type-select').value;
+        const newType = document.getElementById('planet-type-select').value;
+        planet.type = newType;
         planet.name = document.getElementById('planet-name-input').value.trim() || planet.name;
+        if (planet.hiveBonusUnitId && (oldOwner !== newOwnerId || newType !== 'Monde Ruche')) {
+            removeHiveWorldBonus(planet);
+        }
         planet.owner = newOwnerId;
         planet.defense = (planet.owner === 'neutral') ? parseInt(document.getElementById('planet-defense-input').value) || 0 : 0;
     
@@ -1110,6 +1170,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (await showConfirm("Randomiser la planète", "Cette action coûtera <b>2 Points de Réquisition</b>. Continuer ?")) {
             viewingPlayer.requisitionPoints -= 2;
             planet.type = getWeightedRandomPlanetType();
+            if (planet.hiveBonusUnitId && planet.type !== 'Monde Ruche') {
+                removeHiveWorldBonus(planet);
+            }
             logAction(viewingPlayer.id, `A randomisé la planète <b>${planet.name}</b> pour 2 PR. Nouveau type : ${planet.type}.`, 'info', '🎲');
             saveData();
             renderPlanetarySystem(system.id);
@@ -1526,6 +1589,7 @@ document.addEventListener('DOMContentLoaded', () => {
                             attacker.tyranidData.biomassPoints += biomassGained;
                             attacker.requisitionPoints += rpGained;
 
+                        if (planet.hiveBonusUnitId) removeHiveWorldBonus(planet);
                             planet.owner = 'neutral';
                             planet.name = `${planet.name.replace(' (Dévorée)', '')} (Dévorée)`;
                             planet.defense = 0;
@@ -1696,6 +1760,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
                         attacker.tyranidData.biomassPoints += biomassGained;
                         attacker.requisitionPoints += rpGained;
+                        if (planet.hiveBonusUnitId) removeHiveWorldBonus(planet);
 
                         planet.owner = 'neutral';
                         planet.name = `${planet.name.replace(' (Dévorée)', '')} (Dévorée)`;

--- a/render.js
+++ b/render.js
@@ -202,11 +202,15 @@ const renderOrderOfBattle = () => {
         const rank = getRankFromXp(unit.xp);
         const row = document.createElement('tr');
 
-        const isDoubled = unit.equipment && unit.equipment.includes("- Effectif doublé.");
+        const isDoubled = unit.equipment && unit.equipment.includes('- Effectif doublé.');
         const baseName = getUnitDisplayName(unit);
-        const displayName = isDoubled
-            ? `${baseName} <span class="doubled-indicator">x2</span>`
-            : baseName;
+        let displayName = baseName;
+        if (unit.hiveWorldPlanetId) {
+            displayName += ' <span class="hive-bonus-indicator">Ruche</span>';
+        }
+        if (isDoubled) {
+            displayName += ' <span class="doubled-indicator">x2</span>';
+        }
 
         const rankCell = unit.pendingOptimization
             ? `<span class="blink">${rank}</span> <span class="optimisation-disponible">(Optimisation disponible)</span>`
@@ -1059,6 +1063,32 @@ function renderPlanetBonusModal() {
         holySection.innerHTML += '<p>Vous ne contrôlez aucun Monde Saint.</p>';
     }
     contentDiv.appendChild(holySection);
+    contentDiv.appendChild(document.createElement('hr'));
+
+    // --- Section Monde Ruche ---
+    const hiveWorlds = allPlayerPlanets.filter(p => p.type === 'Monde Ruche');
+
+    const hiveSection = document.createElement('div');
+    hiveSection.className = 'bonus-section';
+    hiveSection.innerHTML = `<h4><span class="legend-color" data-type="Monde Ruche"></span> Mondes Ruches (${hiveWorlds.length})</h4>`;
+
+    if (hiveWorlds.length > 0) {
+        hiveWorlds.forEach(planet => {
+            let statusHtml;
+            if (planet.hiveBonusUnitId) {
+                const unit = player.units.find(u => u.id === planet.hiveBonusUnitId);
+                statusHtml = `Bonus assigné à : <strong style="color: var(--friendly-color);">${unit ? getUnitDisplayName(unit) : 'Unité inconnue'}</strong>`;
+            } else {
+                statusHtml = `<button class="btn-secondary assign-hive-bonus-btn" data-planet-id="${planet.id}">Attribuer le Bonus</button>`;
+            }
+            hiveSection.innerHTML += `<p><strong>${planet.name}</strong> (${planet.systemName}): ${statusHtml}</p>`;
+        });
+    } else {
+        hiveSection.innerHTML += '<p>Vous ne contrôlez aucun Monde Ruche.</p>';
+    }
+    contentDiv.appendChild(hiveSection);
+
+    contentDiv.appendChild(document.createElement('hr'));
 
 
     // --- Logique du Timer ---

--- a/style.css
+++ b/style.css
@@ -315,6 +315,19 @@ label {
     border: 1px solid #2475a7;
 }
 
+.hive-bonus-indicator {
+    display: inline-block;
+    background-color: var(--friendly-color);
+    color: #111;
+    padding: 3px 7px;
+    margin-left: 10px;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 0.85em;
+    line-height: 1;
+    vertical-align: middle;
+}
+
 #goals-notes {
     width: 100%;
     min-height: 80px;


### PR DESCRIPTION
## Summary
- allow assigning Hive World bonus to non-character units after capture and in the bonus modal
- mark units with Hive bonus in the roster and list Hive Worlds in the bonus panel
- halve doubling cost for units benefiting from a Hive World

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a991bc594083328806457593986a08