### PR TITLE
feat: support hive world doubling bonus

### DIFF
--- a/engine.js
+++ b/engine.js
@@ -101,6 +101,17 @@ function getUnitDisplayName(unit) {
     return unit.nickname ? `${unit.name} (${unit.nickname})` : unit.name;
 }
 
+function getPlanetById(planetId) {
+    for (const system of campaignData.systems) {
+        for (const planet of system.planets) {
+            if (planet.id === planetId) {
+                return planet;
+            }
+        }
+    }
+    return null;
+}
+
 /**
  * MODIFIÉ : Enregistre une action dans l'historique personnel d'un joueur.
  * @param {string} playerId - L'ID du joueur pour qui enregistrer l'action.

--- a/main.js
+++ b/main.js
@@ -102,6 +102,18 @@ document.addEventListener('DOMContentLoaded', () => {
         return options;
     }
 
+    function removeHiveWorldBonusFromPlanet(planet, oldOwnerId) {
+        if (!planet.hiveBonusUnitId) return;
+        const oldPlayer = campaignData.players.find(p => p.id === oldOwnerId);
+        if (oldPlayer) {
+            const unit = oldPlayer.units.find(u => u.id === planet.hiveBonusUnitId);
+            if (unit && unit.hivePlanetId === planet.id) {
+                delete unit.hivePlanetId;
+            }
+        }
+        delete planet.hiveBonusUnitId;
+    }
+
     function openPostBattleModal(player, planet = null) {
         if (!player) return;
         postBattleModal.dataset.playerId = player.id;
@@ -682,14 +694,29 @@ document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('double-unit-cost-btn').addEventListener('click', () => {
         const unitPowerInput = document.getElementById('unit-power');
         const currentCost = parseInt(unitPowerInput.value) || 0;
-        unitPowerInput.value = currentCost * 2;
-    
+
+        let newCost = currentCost * 2;
+        const player = campaignData.players[activePlayerIndex];
+        const unit = player && editingUnitIndex > -1 ? player.units[editingUnitIndex] : null;
+
+        if (unit && unit.hivePlanetId) {
+            newCost = Math.round(currentCost * 1.5);
+            const planet = getPlanetById(unit.hivePlanetId);
+            if (planet && planet.hiveBonusUnitId === unit.id) {
+                delete planet.hiveBonusUnitId;
+            }
+            delete unit.hivePlanetId;
+            showNotification('Bonus de Monde Ruche utilisé : coût doublé réduit de 50%.', 'success');
+        }
+
+        unitPowerInput.value = newCost;
+
         const equipmentTextarea = document.getElementById('unit-equipment');
         const note = "\n- Effectif doublé.";
         if (!equipmentTextarea.value.includes(note)) {
             equipmentTextarea.value = (equipmentTextarea.value || '').trim() + note;
         }
-    
+
         unitPowerInput.dispatchEvent(new Event('change', { bubbles: true }));
         equipmentTextarea.dispatchEvent(new Event('change', { bubbles: true }));
     });
@@ -733,8 +760,15 @@ document.addEventListener('DOMContentLoaded', () => {
         } else if (target.classList.contains('delete-unit-btn')) {
             const index = parseInt(target.dataset.index);
             const player = campaignData.players[activePlayerIndex];
-            const unitName = player.units[index].name;
+            const unit = player.units[index];
+            const unitName = unit.name;
             if (await showConfirm("Supprimer l'unité", `Supprimer l'unité "<b>${unitName}</b>" de l'ordre de bataille ?`)) {
+                if (unit.hivePlanetId) {
+                    const planet = getPlanetById(unit.hivePlanetId);
+                    if (planet) {
+                        removeHiveWorldBonusFromPlanet(planet, player.id);
+                    }
+                }
                 player.units.splice(index, 1);
                 saveData();
                 renderPlayerDetail();
@@ -1066,33 +1100,62 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    planetTypeForm.addEventListener('submit', (e) => {
+    planetTypeForm.addEventListener('submit', async (e) => {
         e.preventDefault();
         const systemId = document.getElementById('planet-system-id').value;
         const planetIndex = document.getElementById('planet-index').value;
         const system = campaignData.systems.find(s => s.id === systemId);
         const planet = system.planets[planetIndex];
         const oldOwner = planet.owner;
-    
+
         const newOwnerId = document.getElementById('planet-owner-select').value;
         planet.type = document.getElementById('planet-type-select').value;
         planet.name = document.getElementById('planet-name-input').value.trim() || planet.name;
         planet.owner = newOwnerId;
         planet.defense = (planet.owner === 'neutral') ? parseInt(document.getElementById('planet-defense-input').value) || 0 : 0;
-    
+
+        if (planet.type === 'Monde Ruche' && oldOwner !== newOwnerId) {
+            removeHiveWorldBonusFromPlanet(planet, oldOwner);
+            if (newOwnerId !== 'neutral') {
+                const newOwnerPlayer = campaignData.players.find(p => p.id === newOwnerId);
+                const eligibleUnits = (newOwnerPlayer.units || []).filter(u => u.role !== 'Personnage' && u.role !== 'Hero Epique');
+                if (eligibleUnits.length > 0) {
+                    const selectedUnitId = await showUnitChoiceModal(
+                        'Bonus de Monde Ruche',
+                        "Sélectionnez une unité non-personnage pour bénéficier d'une réduction de 50% lors du doublement de son effectif.",
+                        eligibleUnits
+                    );
+                    if (selectedUnitId) {
+                        const unit = newOwnerPlayer.units.find(u => u.id === selectedUnitId);
+                        unit.hivePlanetId = planet.id;
+                        planet.hiveBonusUnitId = unit.id;
+                    }
+                }
+            }
+        } else if (oldOwner !== newOwnerId) {
+            removeHiveWorldBonusFromPlanet(planet, oldOwner);
+        }
+
         if (oldOwner === 'neutral' && newOwnerId !== 'neutral') {
             const newOwnerPlayer = campaignData.players.find(p => p.id === newOwnerId);
             if (newOwnerPlayer) {
                 logAction(newOwnerPlayer.id, `A conquis la planète <b>${planet.name}</b> dans le système <b>${system.name}</b>.`, 'conquest', '🪐');
             }
         }
-    
+
         saveData();
         renderPlanetarySystem(systemId);
         closeModal(planetTypeModal);
-    
+
         if (newOwnerId !== 'neutral') {
             placePlayerSystemOnMap(newOwnerId);
+        }
+
+        if (!playerDetailView.classList.contains('hidden')) {
+            const activeId = campaignData.players[activePlayerIndex]?.id;
+            if (activeId === newOwnerId || activeId === oldOwner) {
+                renderPlayerDetail();
+            }
         }
     });
     

--- a/render.js
+++ b/render.js
@@ -204,9 +204,13 @@ const renderOrderOfBattle = () => {
 
         const isDoubled = unit.equipment && unit.equipment.includes("- Effectif doublé.");
         const baseName = getUnitDisplayName(unit);
-        const displayName = isDoubled
-            ? `${baseName} <span class="doubled-indicator">x2</span>`
-            : baseName;
+        let displayName = baseName;
+        if (isDoubled) {
+            displayName += ' <span class="doubled-indicator">x2</span>';
+        }
+        if (unit.hivePlanetId) {
+            displayName += ' <span class="hive-bonus-indicator" title="Bonus Monde Ruche">🏭</span>';
+        }
 
         const rankCell = unit.pendingOptimization
             ? `<span class="blink">${rank}</span> <span class="optimisation-disponible">(Optimisation disponible)</span>`

--- a/style.css
+++ b/style.css
@@ -315,6 +315,22 @@ label {
     border: 1px solid #2475a7;
 }
 
+/* Indicateur pour le bonus de Monde Ruche */
+.hive-bonus-indicator {
+    display: inline-block;
+    background-color: var(--friendly-color);
+    color: var(--warning-color);
+    padding: 3px 7px;
+    margin-left: 5px;
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 0.85em;
+    line-height: 1;
+    vertical-align: middle;
+    text-shadow: 1px 1px 1px rgba(0,0,0,0.5);
+    border: 1px solid #2d7a46;
+}
+
 #goals-notes {
     width: 100%;
     min-height: 80px;


### PR DESCRIPTION
## Summary
- allow capturing players to grant a Hive World bonus to a non-character unit
- discount doubling costs for that unit and remove bonus if planet lost or unit deleted
- display Hive World bonus indicator in crusade roster

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a99af7fec883329c85bda5e7e6c201